### PR TITLE
Fix union adjacency logic for RationalIntervals

### DIFF
--- a/src/rational-interval.js
+++ b/src/rational-interval.js
@@ -482,10 +482,10 @@ export class RationalInterval {
    * @returns {RationalInterval|null} The union interval, or null if they are disjoint
    */
   union(other) {
-    // Check if intervals are disjoint and not adjacent
-    const oneLow = new Rational(1);
-    const adjacentRight = this.#high.add(oneLow).equals(other.low);
-    const adjacentLeft = other.high.add(oneLow).equals(this.#low);
+    // Check if intervals are disjoint and not adjacent (touching)
+    // Adjacent means they share an endpoint exactly
+    const adjacentRight = this.#high.equals(other.low);
+    const adjacentLeft = other.high.equals(this.#low);
 
     if (!this.overlaps(other) && !adjacentRight && !adjacentLeft) {
       return null;

--- a/tests/rational-interval.test.js
+++ b/tests/rational-interval.test.js
@@ -311,6 +311,23 @@ describe("RationalInterval", () => {
 
       expect(a.union(c)).toBeNull();
     });
+
+    it("unites intervals that share an endpoint", () => {
+      const a = new RationalInterval("0", "1");
+      const b = new RationalInterval("1", "2");
+
+      const union = a.union(b);
+      expect(union).not.toBeNull();
+      expect(union.low.equals(new Rational(0))).toBe(true);
+      expect(union.high.equals(new Rational(2))).toBe(true);
+    });
+
+    it("returns null for intervals separated by a gap", () => {
+      const a = new RationalInterval("0", "1");
+      const b = new RationalInterval("2", "3");
+
+      expect(a.union(b)).toBeNull();
+    });
   });
 
   describe("conversion", () => {


### PR DESCRIPTION
## Summary
- fix RationalInterval.union adjacency detection
- test edge cases for interval union

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68549f5109708332b566e3fa24348340