### PR TITLE
Add invalid level tests for promoteToLevel

### DIFF
--- a/src/type-promotion.js
+++ b/src/type-promotion.js
@@ -58,6 +58,10 @@ export class TypePromotion {
    */
   static promoteToLevel(value, targetLevel) {
     const currentLevel = TypePromotion.getTypeLevel(value);
+
+    if (!Number.isInteger(targetLevel) || targetLevel < 0 || targetLevel > 2) {
+      throw new Error(`Invalid target level: ${targetLevel}`);
+    }
     
     if (currentLevel === targetLevel) {
       return value;

--- a/tests/type-promotion-errors.test.js
+++ b/tests/type-promotion-errors.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "bun:test";
+import { TypePromotion } from "../src/type-promotion.js";
+import { Integer } from "../src/integer.js";
+import { Rational } from "../src/rational.js";
+import { RationalInterval } from "../src/rational-interval.js";
+
+describe("TypePromotion.promoteToLevel error handling", () => {
+  it("throws when target level is greater than 2", () => {
+    const int = new Integer(1);
+    expect(() => TypePromotion.promoteToLevel(int, 3)).toThrow();
+  });
+
+  it("throws when target level is negative", () => {
+    const rat = new Rational(1n, 2n);
+    expect(() => TypePromotion.promoteToLevel(rat, -1)).toThrow();
+  });
+
+  it("throws when target level is not an integer", () => {
+    const interval = new RationalInterval(new Rational(1n, 2n), new Rational(3n, 2n));
+    expect(() => TypePromotion.promoteToLevel(interval, 1.5)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `TypePromotion.promoteToLevel` validates the target level
- add new error-handling tests

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_6854a35be9ac8332a4e2106f4353ece6